### PR TITLE
Added conditional property for creating an SSL gateway

### DIFF
--- a/deploy/terraform/ssl_app_gateway.tf
+++ b/deploy/terraform/ssl_app_gateway.tf
@@ -1,4 +1,5 @@
 module "ssl_app_gateway" {
+  count                     = var.create_ssl_gateway ? 1 : 0
   source                    = "git::https://github.com/amido/stacks-terraform//azurerm/modules/azurerm-app-gateway?ref=feature/update-tf-structure"
   resource_namer            = module.default_label.id
   resource_group_name       = module.aks_bootstrap.resource_group_name

--- a/deploy/terraform/vars.tf
+++ b/deploy/terraform/vars.tf
@@ -92,6 +92,11 @@ variable "create_acr" {
   type = bool
 }
 
+variable "create_ssl_gateway" {
+  type    = bool
+  default = true
+}
+
 variable "acr_resource_group" {
   type = string
 }


### PR DESCRIPTION
## 📲 What

Added ability to conditionally set whether the SSL gateway is deployed or not. Default is "true"

## 🤔 Why

Fore some clients creating an SSL gateway is not required as they already have one in place that they can use. This option allows them to skip this resource.

## 🛠 How

Aded a new conditional variable to the `vars.tf` file:

```
variable "create_ssl_gateway" {
  type    = bool
  default = true
}
```

The SSL Gateway resource now has a `count` property that is set to one of the above variable is set to "true" and 0 if "false".

```
module "ssl_app_gateway" {
  count                     = var.create_ssl_gateway ? 1 : 0
...
```

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA
