### PR TITLE
chore: normalize dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,15 @@ updates:
       interval: weekly
       day: monday
       timezone: Europe/London
+    cooldown:
+      default-days: 5
+    reviewers:
+      - Ensono/stacks-maintainers
+    groups:
+      terraform-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     open-pull-requests-limit: 10
-    rebase-strategy: disabled


### PR DESCRIPTION
## 📲 What

Normalize Dependabot configuration for Terraform updates.

## 🤔 Why

Reduce noisy dependency churn while keeping maintainers assigned to Dependabot PRs.

## 🛠 How

- Add a 5-day Dependabot cooldown.
- Add `Ensono/stacks-maintainers` as reviewer.
- Group Terraform minor and patch updates into one Dependabot PR.
- Remove disabled rebase strategy so Dependabot can rebase updates normally.

## 👀 Evidence

Not run; configuration-only change.

## 🕵️ How to test

Review `.github/dependabot.yml` and confirm next scheduled Dependabot run creates grouped minor/patch Terraform update PRs with maintainers requested.
